### PR TITLE
Fixed the bug with the '-' character from the challenge 9 answer text box

### DIFF
--- a/app/src/main/java/com/andranym/skyblockbazaarstatus/ChallengeActivity.java
+++ b/app/src/main/java/com/andranym/skyblockbazaarstatus/ChallengeActivity.java
@@ -13,6 +13,7 @@ import android.widget.EditText;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.text.method.DigitsKeyListener;
 
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
@@ -106,6 +107,7 @@ public class ChallengeActivity extends AppCompatActivity {
         editNumC7 = findViewById(R.id.editNumC7);
         editNumC8 = findViewById(R.id.editNumC8);
         editNumC9 = findViewById(R.id.editNumC9);
+        editNumC9.setKeyListener(DigitsKeyListener.getInstance("0123456789-"));
         editColor = findViewById(R.id.editColor);
         switchFancyTimer = findViewById(R.id.switchFancyTimer);
         switchArbitrageShortcut = findViewById(R.id.switchArbitrageShortcut);


### PR DESCRIPTION
Imported a library that lets you specify what characters you are allowed to enter in a text box and used it in the challenge 9 answer text box to only allow the "0123456789-" characters to be entered the challenge 9 answer text box.

Also, I've tested it on my phone and it works. 